### PR TITLE
Create People form - added 'remove contact method' button

### DIFF
--- a/apps/hygeia_web/lib/hygeia_web/live/person_live/create.ex
+++ b/apps/hygeia_web/lib/hygeia_web/live/person_live/create.ex
@@ -11,6 +11,8 @@ defmodule HygeiaWeb.PersonLive.Create do
 
   alias Surface.Components.Form
   alias Surface.Components.Form.Field
+  alias Surface.Components.Form.HiddenInput
+  alias Surface.Components.Form.Input.InputContext
   alias Surface.Components.Form.Inputs
 
   alias Surface.Components.Form.Select
@@ -48,16 +50,31 @@ defmodule HygeiaWeb.PersonLive.Create do
   end
 
   def handle_event("add_contact_method", _params, socket) do
-    contact_methods = Ecto.Changeset.get_field(socket.assigns.changeset, :contact_methods, [])
+    {:noreply,
+     assign(
+       socket,
+       :changeset,
+       CaseContext.change_person(
+         %Person{},
+         changeset_add_to_params(socket.assigns.changeset, :contact_methods, %{
+           uuid: Ecto.UUID.generate()
+         })
+       )
+     )}
+  end
 
-    changeset =
-      Ecto.Changeset.put_change(
-        socket.assigns.changeset,
-        :contact_methods,
-        contact_methods ++ [%{}]
-      )
-
-    {:noreply, assign(socket, :changeset, changeset)}
+  def handle_event("remove_contact_method", %{"value" => contact_method_uuid}, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :changeset,
+       CaseContext.change_person(
+         %Person{},
+         changeset_remove_from_params_by_id(socket.assigns.changeset, :contact_methods, %{
+           uuid: contact_method_uuid
+         })
+       )
+     )}
   end
 
   def handle_event(

--- a/apps/hygeia_web/lib/hygeia_web/live/person_live/create.sface
+++ b/apps/hygeia_web/lib/hygeia_web/live/person_live/create.sface
@@ -63,35 +63,49 @@
         <th>{gettext("Type")}</th>
         <th>{gettext("Value")}</th>
         <th>{gettext("Comment")}</th>
+        <th />
       </tr>
     </thead>
     <tbody>
       <Inputs for={:contact_methods}>
-        <tr>
-          <td>
-            <Field name={:type}>
-              <Select
-                class="form-control"
-                opts={prompt: gettext("Choose Type")}
-                field={:type}
-                options={Person.ContactMethod.Type.map()}
-              />
-              <ErrorTag class="d-block invalid-feedback" />
-            </Field>
-          </td>
-          <td>
-            <Field name={:value}>
-              <TextInput class="form-control" field={:value} />
-              <ErrorTag class="d-block invalid-feedback" />
-            </Field>
-          </td>
-          <td>
-            <Field name={:comment}>
-              <TextInput class="form-control" field={:comment} />
-              <ErrorTag class="d-block invalid-feedback" />
-            </Field>
-          </td>
-        </tr>
+        <InputContext assigns={assigns} :let={form: contact_method}>
+          <HiddenInput field={:uuid} />
+          <tr>
+            <td>
+              <Field name={:type}>
+                <Select
+                  class="form-control"
+                  opts={prompt: gettext("Choose Type")}
+                  field={:type}
+                  options={Person.ContactMethod.Type.map()}
+                />
+                <ErrorTag class="d-block invalid-feedback" />
+              </Field>
+            </td>
+            <td>
+              <Field name={:value}>
+                <TextInput class="form-control" field={:value} />
+                <ErrorTag class="d-block invalid-feedback" />
+              </Field>
+            </td>
+            <td>
+              <Field name={:comment}>
+                <TextInput class="form-control" field={:comment} />
+                <ErrorTag class="d-block invalid-feedback" />
+              </Field>
+            </td>
+            <td>
+              <button
+                type="button"
+                class="btn btn-danger"
+                :on-click="remove_contact_method"
+                value={Ecto.Changeset.fetch_field!(contact_method.source, :uuid)}
+              >
+                <span class="oi oi-trash" aria-hidden="true" />
+              </button>
+            </td>
+          </tr>
+        </InputContext>
       </Inputs>
     </tbody>
   </table>


### PR DESCRIPTION
A 'remove contact method' button was missing for the create person form (currently reachable at path: /people/new)