### PR TITLE
Communication - fix error when person surname is nil

### DIFF
--- a/lib/hygeia/auto_tracing_context/auto_tracing_communication.ex
+++ b/lib/hygeia/auto_tracing_context/auto_tracing_communication.ex
@@ -29,7 +29,7 @@ defmodule Hygeia.AutoTracingContext.AutoTracingCommunication do
         public_overview_link: @url_generator.overview_url(case),
         message_signature: Tenant.get_message_signature_text(case.tenant, :sms),
         initial_first_name: String.slice(case.person.first_name, 0..0),
-        initial_last_name: String.slice(case.person.last_name, 0..0)
+        initial_last_name: String.slice(case.person.last_name || "", 0..0)
       )
 
   @spec auto_tracing_email_subject(case :: Case.t()) :: String.t()
@@ -57,7 +57,7 @@ defmodule Hygeia.AutoTracingContext.AutoTracingCommunication do
       public_overview_link: @url_generator.overview_url(case),
       message_signature: Tenant.get_message_signature_text(case.tenant, :email),
       initial_first_name: String.slice(case.person.first_name, 0..0),
-      initial_last_name: String.slice(case.person.last_name, 0..0)
+      initial_last_name: String.slice(case.person.last_name || "", 0..0)
     )
   end
 end

--- a/lib/hygeia/jobs/send_case_closed_email.ex
+++ b/lib/hygeia/jobs/send_case_closed_email.ex
@@ -93,7 +93,7 @@ defmodule Hygeia.Jobs.SendCaseClosedEmail do
       isolation_end_confirmation_link: @url_generator.pdf_url(case, phase),
       message_signature: Tenant.get_message_signature_text(case.tenant, message_type),
       initial_first_name: String.slice(case.person.first_name, 0..0),
-      initial_last_name: String.slice(case.person.last_name, 0..0)
+      initial_last_name: String.slice(case.person.last_name || "", 0..0)
     )
   end
 

--- a/lib/hygeia_web/helpers/confirmation.ex
+++ b/lib/hygeia_web/helpers/confirmation.ex
@@ -49,7 +49,7 @@ defmodule HygeiaWeb.Helpers.Confirmation do
       public_overview_link: public_overview_link(conn_or_socket, case),
       message_signature: Tenant.get_message_signature_text(case.tenant, message_type),
       initial_first_name: String.slice(case.person.first_name, 0..0),
-      initial_last_name: String.slice(case.person.last_name, 0..0)
+      initial_last_name: String.slice(case.person.last_name || "", 0..0)
     )
   end
 
@@ -96,7 +96,7 @@ defmodule HygeiaWeb.Helpers.Confirmation do
       public_overview_link: public_overview_link(conn_or_socket, case),
       message_signature: Tenant.get_message_signature_text(case.tenant, message_type),
       initial_first_name: String.slice(case.person.first_name, 0..0),
-      initial_last_name: String.slice(case.person.last_name, 0..0)
+      initial_last_name: String.slice(case.person.last_name || "", 0..0)
     )
   end
 


### PR DESCRIPTION
An error was occurring when a case was inserted for a person without a surname (nil).